### PR TITLE
Add support for extra parameters definition on action callback

### DIFF
--- a/src/action_manager/action_executor.py
+++ b/src/action_manager/action_executor.py
@@ -20,7 +20,6 @@ class ActionExecutor:
                 request_body[args_names[i]] = args_values[i]
 
         return {
-            "request": self.action.callback.request,
-            "url": self.action.callback.url,
+            "params": self.action.callback.params,
             "body": request_body
         }

--- a/src/actions/action_callback.py
+++ b/src/actions/action_callback.py
@@ -1,12 +1,11 @@
-from typing import List
+from typing import List, Dict
 
 
 class ActionCallback:
-    request: str
-    url: str
-    arguments: List[str]
+	params: Dict[str,str]
+	arguments: List[str]
 
-    def __init__(self, request: str, url: str, arguments: List[str]):
-        self.request = request
-        self.url = url
-        self.arguments = arguments
+	def __init__(self, params: Dict[str,str], arguments: List[str]):
+		_ = params.pop('arguments', None)
+		self.params = params
+		self.arguments = arguments

--- a/src/actions/actions.py
+++ b/src/actions/actions.py
@@ -20,7 +20,6 @@ class Actions:
         self.actions = file_to_action_parser.parse_dir(self.catalog_path + "/")
 
     def listen_actions_changes(self):
-        print(self.catalog_path + "/")
         observer = Observer()
         observer.schedule(ActionChangeHandler(self.catalog_path + "/", self.actions), self.catalog_path, recursive=True)
         observer.start()

--- a/src/actions/file_to_action_parser.py
+++ b/src/actions/file_to_action_parser.py
@@ -39,7 +39,7 @@ def get_callback_from_yaml(data):
     callback = data['callback']
     arguments = callback.get('arguments', [])
 
-    return ActionCallback(callback['request'], callback['url'], arguments)
+    return ActionCallback(callback, arguments)
 
 
 def yaml_to_action(data, action_name: str):


### PR DESCRIPTION
As the name suggests, this PR provides the freedom to add any type of parameters as a callback of the action.
In the example of the _SelectOptionAction_, the response will be:
```
{"params": {"request": "POST", "url": "http://localhost:3000/answer"}, "body": {"answer": 1}}
```